### PR TITLE
Add support for NPM Taskrunner extension in visual studio

### DIFF
--- a/package-template/package.json
+++ b/package-template/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "mypackage",
+    "private": "true",
+    "version": "0.0.0",
+    "type": "commonjs",
+    "description": "proxy package.json, so NPM Taskrunner extension in visual studio can find the commands",
+    "scripts": {
+        "build": "cd ./MyPackage.Client/Assets/ && npm run build",
+        "watch": "cd ./MyPackage.Client/Assets/ && npm run watch"
+    }
+}


### PR DESCRIPTION
npm task runner requires package.json to appear in root of solution, 
so we have a proxy package.json so the tasks from the client folder will then run.

## Extension :
- https://marketplace.visualstudio.com/items?itemName=MadsKristensen.NpmTaskRunner64&ssr=false#overview

## Package fix comment
- https://marketplace.visualstudio.com/items?itemName=MadsKristensen.NpmTaskRunner64&ssr=false#qna